### PR TITLE
remove babel version string from scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     }
   },
   "scripts": {
-    "babel-eslint": "^8.0.3",
     "lint": "eslint .",
     "test": "echo 'placeholder. no tests implemented'"
   },


### PR DESCRIPTION
The line in question appears to have been accidentally cut-and-pasted from
the devDependencies section.