### PR TITLE
use current stripes-form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-myprofile
 
+## 0.3.0 (IN PROGRESS)
+
+* Update to stripes-form 0.9.0. Refs STRIPES-555.
+
 ## [0.2.0](https://github.com/folio-org/ui-myprofile/tree/v0.2.0) (2018-09-05)
 [Full Changelog](https://github.com/folio-org/ui-myprofile/compare/v0.1.0...v0.2.0)
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@folio/stripes-components": "^3.0.0",
     "@folio/stripes-smart-components": "^1.4.0",
     "@folio/react-intl-safe-html": "^1.0.1",
-    "@folio/stripes-form": "^0.8.0",
+    "@folio/stripes-form": "^0.9.0",
     "react-intl": "^2.3.0",
     "prop-types": "^15.6.0",
     "redux-form": "^7.0.3",


### PR DESCRIPTION
Because stripes-form has not been released as a v1.0.x package,
this means ^0.8.0 is effectively ~0.8.0, meaning those packages
are locked at 0.8.x, not 0.x.x as intended. stripes-form 0.8.0
pulled in an old version of stripes-components which pulled in
an old version of React which brought darkness upon the land.

Refs [STRIPES-555](https://issues.folio.org/browse/STRIPES-555)