### PR TITLE
FOLIO-1707 Remove stripes cli from dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-myprofile
 
+## [1.3.0](https://github.com/folio-org/ui-myprofile/tree/v1.3.0) (2019-01-16)
+[Full Changelog](https://github.com/folio-org/ui-myprofile/compare/v1.2.0...v1.3.0)
+
+* Remove stripes-cli from dependencies
+
 ## [1.2.0](https://github.com/folio-org/ui-myprofile/tree/v1.2.0) (2018-12-11)
 [Full Changelog](https://github.com/folio-org/ui-myprofile/compare/v1.1.0...v1.2.0)
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.1",
-    "@folio/stripes-cli": "^1.4.0",
     "prop-types": "^15.6.0",
     "react-intl": "^2.3.0",
     "react-router-dom": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/myprofile",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "My profile",
   "repository": "folio-org/ui-myprofile",
   "publishConfig": {


### PR DESCRIPTION
When I tried to pin the version of `stripes-cli` requested by `platform-core`, I got multiple versions. The extra newer version came from here.

Introduced in https://github.com/folio-org/ui-myprofile/pull/18 and not caught in https://github.com/folio-org/ui-myprofile/pull/21