### PR TITLE
UITEN-35 use granular permissoins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-myprofile
 
+## 1.7.0 (IN PROGRESS)
+
+* Use granular permissions. (UITEN-35)
+
 ## [1.6.0](https://github.com/folio-org/ui-myprofile/tree/v1.6.0) (2019-05-06)
 [Full Changelog](https://github.com/folio-org/ui-myprofile/compare/v1.5.0...v1.6.0)
 


### PR DESCRIPTION
Instead of a single setting to determine visibility of settings items,
use per-item permissions.

Refs [UITEN-35](https://issues.folio.org/browse/UITEN-35)