### PR TITLE
UITEN-35 use granular permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,19 +17,18 @@
     "permissionSets": [
       {
         "permissionName": "module.myprofile.enabled",
-        "displayName": "UI: Users profile module is enabled"
+        "displayName": "UI: My-profile module is enabled"
       },
       {
         "permissionName": "settings.myprofile.enabled",
-        "displayName": "Settings (Users profile): display list of settings pages",
+        "displayName": "Settings (My profile): display list of settings pages",
         "subPermissions": [
           "settings.enabled"
-        ],
-        "visible": true
+        ]
       },
       {
-        "permissionName": "ui-myprofile.view",
-        "displayName": "My profile: Can change your local password",
+        "permissionName": "ui-myprofile.settings.change-password",
+        "displayName": "Settings (My profile): Can change your local password",
         "description": "Some subperms can be deleted later when submodules use modern permission names",
         "subPermissions": [
           "settings.myprofile.enabled",

--- a/settings/index.js
+++ b/settings/index.js
@@ -42,7 +42,7 @@ class MyProfile extends Component {
       route: 'password',
       label: <FormattedMessage id="ui-myprofile.settings.changePassword.label" />,
       component: ChangePassword,
-      perm: 'ui-myprofile.view',
+      perm: 'ui-myprofile.settings.change-password',
     };
 
     return changePasswordPageSettings;


### PR DESCRIPTION
Actually _do_ the thing #79 said it was going to do, i.e. instead
of using the generic "show settings page" permission, use per-item
permissions.

Refs [UITEN-35](https://issues.folio.org/browse/UITEN-35)