### PR TITLE
bump to version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change history for ui-myprofile
 
-## [1.9.0](IN PROGRESS)
+## [2.0.0](IN PROGRESS)
 
 * Update eslint to v6.2.1. Refs UIMPROF-41.
+* Migrate to `stripes` `v3.0.0` and move `react-intl` and `react-router` to peerDependencies.
 
 ## [1.8.0](https://github.com/folio-org/ui-myprofile/tree/v1.8.0) (2019-12-03)
 [Full Changelog](https://github.com/folio-org/ui-myprofile/compare/v1.7.0...v1.8.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/myprofile",
-  "version": "1.8.0",
+  "version": "2.0.0",
   "description": "My profile",
   "repository": "folio-org/ui-myprofile",
   "publishConfig": {
@@ -64,9 +64,9 @@
     "@bigtest/mocha": "^0.5.0",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.1.0",
-    "@folio/stripes": "^2.13.0",
+    "@folio/stripes": "^3.0.0",
     "@folio/stripes-cli": "^1.11.0",
-    "@folio/stripes-core": "^3.12.0",
+    "@folio/stripes-core": "^4.0.0",
     "babel-eslint": "^10.0.3",
     "regenerator-runtime": "^0.13.3",
     "core-js": "^3.6.4",
@@ -78,6 +78,7 @@
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
     "react-redux": "^5.0.7",
+    "react-router-dom": "^4.1.1",
     "react-trigger-change": "^1.0.2",
     "redux": "^4.0.0",
     "sinon": "^6.3.4",
@@ -86,12 +87,12 @@
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.1",
     "prop-types": "^15.6.0",
-    "react-intl": "^2.3.0",
-    "react-router-dom": "^4.1.1",
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {
     "@folio/stripes": "^2.13.0",
-    "react": "*"
+    "react": "*",
+    "react-intl": "^2.3.0",
+    "react-router-dom": "^4.1.1"
   }
 }


### PR DESCRIPTION
Why a new major version?

* bump the `@folio/stripes` peer to `v3.0.0`
* move `react-router` related things to peerDependencies
* move `react-intl` to peerDependencies