### PR TITLE
avoid setState in unmounted components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Purge `intlShape` in prep for `react-intl` `v4` migration. Update to `@folio/stripes` `v4.0.0`. Refs STRIPES-672.
 * Prefer `stripes.actsAs` to the deprecated `stripes.type` in `package.json`. Refs STCOR-148.
 * Migrate `react-intl-safe-html` to `v2.0`. Refs STRIPES-672.
+* Avoid calling `setState` from a promise that may resolve after unmount.
 
 ## [2.0.0](https://github.com/folio-org/ui-myprofile/tree/v2.0.0) (2020-03-13)
 [Full Changelog](https://github.com/folio-org/ui-myprofile/compare/v1.8.0...v2.0.0)

--- a/settings/ChangePassword/ChangePassword.js
+++ b/settings/ChangePassword/ChangePassword.js
@@ -69,6 +69,14 @@ class ChangePassword extends Component {
     };
   }
 
+  componentDidMount() {
+    this._isMounted = true;
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
   togglePasswordMask = () => {
     this.setState(({ passwordMasked }) => ({
       passwordMasked: !passwordMasked,
@@ -106,7 +114,9 @@ class ChangePassword extends Component {
         newPassword,
       })
       .then(() => {
-        this.handleChangePasswordSuccess();
+        if (this._isMounted) {
+          this.handleChangePasswordSuccess();
+        }
       })
       .catch(this.handleChangePasswordError);
   };


### PR DESCRIPTION
A promise may return after a component has unmounted. In this case, it
should avoid calling `setState`.