### PR TITLE
UIMPROF-63 upgrade react-intl-safe-html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change history for ui-myprofile
 
-### 6.0.0 (https://github.com/folio-org/ui-myprofile/tree/v6.0.0) (2021-10-01)
+## IN PROGRESS
+
+* Upgrade `@folio/react-intl-safe-html` for compatibility with `@folio/stripes` `v7`. Refs UIMPROF-63.
+
+## 6.0.0 (https://github.com/folio-org/ui-myprofile/tree/v6.0.0) (2021-10-01)
 * Compile Translation Files into AST Format. Refs UIMPROF-57.
 * Increment stripes to v7 and react v17. Refs UIMPROF-60.
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "webpack": "^4.10.2"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^2.0.0",
+    "@folio/react-intl-safe-html": "^3.1.0",
     "prop-types": "^15.6.0",
     "redux-form": "^8.3.7"
   },


### PR DESCRIPTION
Upgrade `@folio/react-intl-safe-html` for compatibility with
`@folio/stripes` `v7` (react 17, react-intl 5).

Refs [UIMPROF-63](https://issues.folio.org/browse/UIMPROF-63), [STRIPES-769](https://issues.folio.org/browse/STRIPES-769)