### PR TITLE
UIMPROF-66 Undefined permission 'validation.rules.collection.get'

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,9 @@
         "description": "Some subperms can be deleted later when submodules use modern permission names",
         "subPermissions": [
           "settings.myprofile.enabled",
-          "validation.rules.collection.get",
           "users.collection.get",
           "users-bl.item.get",
-          "users.item.get",
-          "login.item.get"
+          "users.item.get"
         ],
         "visible": true
       }


### PR DESCRIPTION
## Description
Removed permissions are no longer needed for /tenant/rules endpoint

## Issues
[UIMPROF-66](https://issues.folio.org/browse/UIMPROF-66)

Co-authored-by: Denys Bohdan <denys_bohdan@epam.com>