### PR TITLE
UIMPROF-58: Refactor away from react-intl-safe-html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-myprofile
 
+## IN PROGRESS
+
+* Refactor away from `react-intl-safe-html`. Refs UIMPROF-58.
+
 ## 7.0.0 (https://github.com/folio-org/ui-myprofile/tree/v7.0.0) (2022-03-01)
 [Full Changelog](https://github.com/folio-org/ui-myprofile/compare/v6.0.0...v7.0.0)
 

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "webpack": "^4.10.2"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^3.1.0",
     "eslint-import-resolver-webpack": "^0.13.2",
     "prop-types": "^15.6.0",
     "redux-form": "^8.3.7"

--- a/src/settings/ChangePassword/ChangePassword.js
+++ b/src/settings/ChangePassword/ChangePassword.js
@@ -6,7 +6,6 @@ import {
 } from 'redux-form';
 import { FormattedMessage } from 'react-intl';
 
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import {
   PasswordStrength,
   TextField,
@@ -123,7 +122,7 @@ class ChangePassword extends Component {
 
   handleChangePasswordSuccess = () => {
     const successMessage = (
-      <SafeHTMLMessage
+      <FormattedMessage
         id="ui-myprofile.settings.changePassword.successfullyChanged"
         values={this.getFullUserName()}
       />


### PR DESCRIPTION
## Purpose
Refactor away from `react-intl-safe-html`.

Issue: [UIMPROF-58](https://issues.folio.org/browse/UIMPROF-58)