### PR TITLE
FOLIO-3477 : FE: update outdated dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Refactor away from `react-intl-safe-html`. Refs UIMPROF-58.
 * Replace `babel-eslint` with `@babel/eslint-parser`. Refs UIMPROF-68.
+* FE: update outdated dependencies. Refs FOLIO-3477.
 
 ## 7.0.0 (https://github.com/folio-org/ui-myprofile/tree/v7.0.0) (2022-03-01)
 [Full Changelog](https://github.com/folio-org/ui-myprofile/compare/v6.0.0...v7.0.0)

--- a/package.json
+++ b/package.json
@@ -84,20 +84,19 @@
     "jest-junit": "^12.0.0",
     "jquery": "^3.3.1",
     "mocha": "^5.2.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-intl": "^5.8.0",
     "react-redux": "^7.2.2",
-    "react-router-dom": "^5.0.0",
     "react-trigger-change": "^1.0.2",
     "redux": "^4.0.0",
     "regenerator-runtime": "^0.13.3",
     "webpack": "^4.10.2"
   },
   "dependencies": {
-    "eslint-import-resolver-webpack": "^0.13.2",
     "prop-types": "^15.6.0",
-    "redux-form": "^8.3.7"
+    "redux-form": "^8.3.7",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-intl": "^5.8.0",
+    "react-router-dom": "^5.0.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^7.0.0",


### PR DESCRIPTION
### **Purpose**
Issue: [FE: update outdated dependencies](https://issues.folio.org/browse/FOLIO-3477)
FE: update outdated dependencies

### Approach
I have cloned "Platform-Complete", checked out the branch "snapshot" and ran "yarn install".
Here I could see
1. no warnings while resolving the packages.(reference: screenshot1)
2. three warnings(pertaining to those modules owned by Spitfire Team ) while linking dependencies (reference: screenshot2)
3. **eslint-import-resolver-webpack** has been removed from package.json and verified that it did not cause any side effects.
4. moved **react, react-dom, react-intl, react-router-dom** packages from devDependencies to dependencies. This removes the linking warnings while yarn install.
5. verified that there are no  warnings while "resolving packages" and "linking packages" at both sample-platform level and module level "yarn install". Hope this will clear the linking warning on "platform-complete" as well.

### Learning
When a dependency is listed in a package as a peerDependency, it is not automatically installed. Instead, the code that includes the package must include it as its dependency.
Reference: https://flaviocopes.com/npm-peer-dependencies/

### Screenshots
1.
![image](https://user-images.githubusercontent.com/104053200/168072086-d8db2102-1833-4ad9-b738-c385f0414c0d.png)
6.
![image](https://user-images.githubusercontent.com/104053200/168072113-12fb956b-1fa6-49d6-a75e-0eae95b9e485.png)
