### PR TITLE
FOLIO-3477 : FE: update outdated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,11 @@
     "jest-junit": "^12.0.0",
     "jquery": "^3.3.1",
     "mocha": "^5.2.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-intl": "^5.8.0",
     "react-redux": "^7.2.2",
+    "react-router-dom": "^5.0.0",
     "react-trigger-change": "^1.0.2",
     "redux": "^4.0.0",
     "regenerator-runtime": "^0.13.3",
@@ -92,11 +96,7 @@
   },
   "dependencies": {
     "prop-types": "^15.6.0",
-    "redux-form": "^8.3.7",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-intl": "^5.8.0",
-    "react-router-dom": "^5.0.0"
+    "redux-form": "^8.3.7"
   },
   "peerDependencies": {
     "@folio/stripes": "^7.0.0",


### PR DESCRIPTION
### Purpose
Issue: [FE: update outdated dependencies](https://issues.folio.org/browse/FOLIO-3477)
FE: update outdated dependencies

### Approach
Could not revert pr#185 as there were changes ahead of merging it.
Hence reverting few changes of earlier pr #185, moving back those dependencies that were moved from "devDependencies" to "dependencies"