### PR TITLE
UIMPROF-78 Upgrade react-redux to v8.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change history for ui-myprofile
 
-## 7.3.0 (IN PROGRESS)
+## 8.0.0 (IN PROGRESS)
 * Save button remains enabled despite validation errors on My profile form. Refs UIMPROF-76.
+* Upgrade `react-redux` to `v8`. Bump `stripes-*` to next version. Refs UIMPROF-78.
 
 ## 7.2.0 (https://github.com/folio-org/ui-myprofile/tree/v7.2.0) (2022-10-25)
 [Full Changelog](https://github.com/folio-org/ui-myprofile/compare/v7.1.0...v7.2.0)

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@folio/stripes": "^8.0.0",
     "@folio/stripes-cli": "^2.4.0",
     "@folio/stripes-components": "^11.0.0",
-    "@folio/stripes-connect": "^8.0.0",
+    "@folio/stripes-connect": "^8.1.0",
     "@folio/stripes-core": "^9.0.0",
     "@folio/stripes-logger": "^1.0.0",
     "@formatjs/cli": "^4.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/myprofile",
-  "version": "7.2.0",
+  "version": "8.0.0",
   "description": "My profile",
   "repository": "folio-org/ui-myprofile",
   "publishConfig": {
@@ -67,11 +67,11 @@
     "@babel/plugin-transform-runtime": "^7.13.7",
     "@babel/preset-react": "^7.16.7",
     "@folio/eslint-config-stripes": "^6.1.0",
-    "@folio/stripes": "^7.1.0",
+    "@folio/stripes": "^8.0.0",
     "@folio/stripes-cli": "^2.4.0",
-    "@folio/stripes-components": "^10.0.0",
-    "@folio/stripes-connect": "^7.0.0",
-    "@folio/stripes-core": "^8.0.0",
+    "@folio/stripes-components": "^11.0.0",
+    "@folio/stripes-connect": "^8.0.0",
+    "@folio/stripes-core": "^9.0.0",
     "@folio/stripes-logger": "^1.0.0",
     "@formatjs/cli": "^4.2.7",
     "@testing-library/jest-dom": "^5.11.9",
@@ -91,7 +91,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.0",
-    "react-redux": "^7.2.2",
+    "react-redux": "^8.0.5",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.0.0",
     "react-trigger-change": "^1.0.2",
@@ -106,10 +106,11 @@
     "redux-form": "^8.3.7"
   },
   "peerDependencies": {
-    "@folio/stripes": "^7.0.0",
+    "@folio/stripes": "^8.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.0",
+    "react-redux": "^8.0.5",
     "react-router-dom": "^5.0.0"
   }
 }


### PR DESCRIPTION
- Refs https://issues.folio.org/browse/UIMPROF-78.
- Upgrade will be happening across all of Stripes framework and modules that reference react-redux.
- v7 to v8 is a very harmless upgrade and is only considered breaking since they removed a few rarely used functions (which I confirmed we don't use). See https://github.com/reduxjs/react-redux/releases/tag/v8.0.0 for more details.