### PR TITLE
Use branch of ui workflow with Sonarcube-scan-action...

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   ui:
     # Use the shared workflow from https://github.com/folio-org/.github
-    uses: folio-org/.github#FOLIO-4190/.github/workflows/ui.yml@v1
+    uses: folio-org/.github/.github/workflows/ui.yml@FOLIO-4190
     # Only handle push events from the main branch or tags, to decrease PR noise
     if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push' || github.ref_type == 'tag'
     secrets: inherit


### PR DESCRIPTION
Last PR is breaking due to Sonarcloud scan not running and griping about an old node version. Since the old sonarcube action is, well, old we have to upgrade to a new one... testing for science...