### PR TITLE
UIMPROF-103 replace annotations for esbuild-loader compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * *BREAKING* Migrate stripes dependencies to their Sunflower versions. Refs UIMPROF-101.
 * *BREAKING* Migrate react-intl to v7. Refs UIMPROF-102.
+* Replace annotations. Refs UIMPROF-103.
 
 ## 9.2.0 (https://github.com/folio-org/ui-myprofile/tree/v9.2.0) (2024-10-29)
 [Full Changelog](https://github.com/folio-org/ui-myprofile/compare/v9.1.0...v9.2.0)

--- a/src/settings/ChangePassword/ChangePassword.js
+++ b/src/settings/ChangePassword/ChangePassword.js
@@ -19,7 +19,6 @@ import { PasswordValidationField } from '@folio/stripes/smart-components';
 
 import ChangePasswordForm from './ChangePasswordForm';
 
-@stripesConnect
 class ChangePassword extends Component {
   static propTypes = {
     stripes: stripesShape,
@@ -290,4 +289,4 @@ class ChangePassword extends Component {
   }
 }
 
-export default injectIntl(ChangePassword);
+export default injectIntl(stripesConnect(ChangePassword));


### PR DESCRIPTION
Annotations should be just fine, but somehow our esbuild-loader config chokes on them. Luckily they are easy to replace.

Refs [UIMPROF-103](https://folio-org.atlassian.net/browse/UIMPROF-103)
