### PR TITLE
UIMPROF-107: LanguageLocalization setting - add `isEnabled` flag for user settings (follow-up).

### DIFF
--- a/src/settings/LanguageLocalization/LanguageLocalization.js
+++ b/src/settings/LanguageLocalization/LanguageLocalization.js
@@ -47,21 +47,23 @@ const LanguageLocalization = () => {
   }, [intl, tenantSettings]);
 
   const formatPayload = (newSettings) => {
+    const userLocale = newSettings[fieldNames.LOCALE];
+    const tenantLocale = tenantSettings[fieldNames.LOCALE];
+
     return {
       ...initialSettings.current,
       ...newSettings,
+      isEnabled: userLocale !== tenantLocale,
     };
   };
 
-  const afterSave = ({ value: settings }) => {
-    const userLocale = settings[fieldNames.LOCALE];
+  const afterSave = ({ value: userSettings }) => {
     const tenantLocale = tenantSettings[fieldNames.LOCALE];
 
-    let locale = settings[fieldNames.LOCALE];
+    let locale = userSettings[fieldNames.LOCALE];
+    let numberingSystem = userSettings.numberingSystem;
 
-    let numberingSystem = settings.numberingSystem;
-
-    if (userLocale === tenantLocale) {
+    if (!userSettings.isEnabled) {
       locale = tenantLocale;
       numberingSystem = tenantSettings.numberingSystem;
     }
@@ -78,8 +80,14 @@ const LanguageLocalization = () => {
 
     initialSettings.current = initialUserSettings;
 
+    let locale = userLocale;
+
+    if (!initialUserSettings?.isEnabled) {
+      locale = tenantLocale;
+    }
+
     return {
-      [fieldNames.LOCALE]: userLocale || tenantLocale,
+      [fieldNames.LOCALE]: locale,
     };
   };
 

--- a/src/settings/LanguageLocalization/LanguageLocalization.test.js
+++ b/src/settings/LanguageLocalization/LanguageLocalization.test.js
@@ -24,6 +24,7 @@ const userSettings = {
   locale: 'en-GB',
   currency: 'TRY',
   numberingSystem: 'arab',
+  isEnabled: false,
 };
 
 const mockSetLocale = jest.fn();
@@ -72,7 +73,7 @@ describe('LanguageLocalization', () => {
     }), {});
   });
 
-  describe('when there is a locale in user settings', () => {
+  describe('when there is a locale in user settings and `isEnabled` is true', () => {
     it('should display the user locale', async () => {
       renderLanguageLocalization();
 
@@ -82,6 +83,7 @@ describe('LanguageLocalization', () => {
           numberingSystem: 'arab',
           currency: 'TRY',
           timezone: 'Europe/Dublin',
+          isEnabled: true,
         },
       }]));
 
@@ -121,6 +123,7 @@ describe('LanguageLocalization', () => {
     expect(payload).toEqual({
       ...userSettings,
       ...newUserSettings,
+      isEnabled: true,
     });
   });
 
@@ -136,12 +139,15 @@ describe('LanguageLocalization', () => {
     });
   });
 
-  describe('when user selects the locale that does not match the tenant locale', () => {
+  describe('when user selects the locale that does not match the tenant locale and `isEnabled` is true', () => {
     it('should apply user locale', () => {
       renderLanguageLocalization();
 
       ConfigManager.mock.calls[0][0].onAfterSave({
-        value: userSettings,
+        value: {
+          ...userSettings,
+          isEnabled: true,
+        },
       });
 
       expect(mockSetLocale).toHaveBeenCalledWith('en-GB-u-nu-arab');


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIMPROF-4 Access Change my password from Folio Top Toolbar
-->

## Description
User locale settings must follow the tenant's locale settings when the tenant's locale is selected in `Settings - My profile - language localization`. Currently in stripes-core we apply the tenant's locale settings only if user has not set their own locale or their locale is the same as the tenant's locale `if (!userLocaleSettings?.locale || userLocaleSettings?.locale === tenantLocaleSettings?.locale) {}`, but the tenant's locale can be changed and the condition ` userLocaleSettings?.locale === tenantLocaleSettings?.locale` will not be true anymore. The solution is to add the `isEnabled` flag which will indicate whether we need to use user's settings or not. The condition will be changed in stripes-core too.

The recording of the issue is the first [video ](https://folio-org.atlassian.net/browse/UIMPROF-107?focusedCommentId=263844).
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIMPROF-4
 -->

## Related PRs
https://github.com/folio-org/stripes-core/pull/1633

## Issues
[UIMPROF-107](https://folio-org.atlassian.net/browse/UIMPROF-107?focusedCommentId=263844)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Screencasts

https://github.com/user-attachments/assets/96908ea3-a7f2-49d4-93fd-61483463ee92



#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
