### PR TITLE
UIMPROF-115 User preference: Select a language > Reset to tenant default language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 11.0.0 IN PROGRESS
 
 * *BREAKING* Add `Language & Localization` setting. Refs UIMPROF-107.
+* User preference: Select a language > Reset to tenant default language. Refs UIMPROF-115.
 
 ## 10.0.0 (https://github.com/folio-org/ui-myprofile/tree/v10.0.0) (2025-03-14)
 [Full Changelog](https://github.com/folio-org/ui-myprofile/compare/v9.2.0...v10.0.0)

--- a/src/settings/LanguageLocalization/LanguageLocalization.js
+++ b/src/settings/LanguageLocalization/LanguageLocalization.js
@@ -1,12 +1,16 @@
 import {
+  useCallback,
   useMemo,
   useRef,
 } from 'react';
 import { Field } from 'react-final-form';
-import { useIntl } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
+import { config } from 'stripes-config';
 import {
+  Button,
   CommandList,
+  PaneMenu,
   Select,
   defaultKeyboardShortcuts
 } from '@folio/stripes/components';
@@ -39,49 +43,74 @@ const LanguageLocalization = () => {
     key: tenantLocaleConfig.KEY,
   });
 
+  const {
+    settings: userSettings,
+    updateSetting: updateUserSetting,
+  } = useSettings({
+    scope: userOwnLocaleConfig.SCOPE,
+    key: userOwnLocaleConfig.KEY,
+    userId: stripes.user?.user?.id,
+  });
+
   const ConnectedConfigManager = useMemo(() => stripes.connect(ConfigManager), [stripes]);
   const paneTitle = intl.formatMessage({ id: 'ui-myprofile.settings.languageLocalization.label' });
+  const userHasSetLocalePreferences = !!userSettings[fieldNames.LOCALE];
 
-  const localesOptions = useMemo(() => {
-    return localesList(intl, tenantSettings[fieldNames.LOCALE]);
-  }, [intl, tenantSettings]);
+  // tenant configuration might not have a set locale - try stripes-config locale and default to en-US
+  const tenantLocale = tenantSettings[fieldNames.LOCALE] || config.locale || 'en-US';
+  const localesOptions = useMemo(() => localesList(intl, tenantSettings[fieldNames.LOCALE]), [intl, tenantSettings]);
 
   const formatPayload = (newSettings) => {
     return {
-      ...initialSettings.current,
+      [fieldNames.LOCALE]: initialSettings.current,
       ...newSettings,
     };
   };
 
   const afterSave = ({ value: settings }) => {
-    const userLocale = settings[fieldNames.LOCALE];
-    const tenantLocale = tenantSettings[fieldNames.LOCALE];
-
-    let locale = settings[fieldNames.LOCALE];
-
-    let numberingSystem = settings.numberingSystem;
-
-    if (userLocale === tenantLocale) {
-      locale = tenantLocale;
-      numberingSystem = tenantSettings.numberingSystem;
-    }
-
+    const locale = settings[fieldNames.LOCALE];
+    // user can't select numbering system in My Profile, so we can just use tenant settings
+    const numberingSystem = tenantSettings.numberingSystem;
     const fullLocale = getFullLocale(locale, numberingSystem);
 
     stripes.setLocale(fullLocale);
   };
 
-  const getInitialValues = ([data]) => {
-    const initialUserSettings = data?.value;
-    const userLocale = initialUserSettings?.[fieldNames.LOCALE];
-    const tenantLocale = tenantSettings[fieldNames.LOCALE];
+  const getInitialValues = () => {
+    const userLocale = userSettings?.[fieldNames.LOCALE];
 
-    initialSettings.current = initialUserSettings;
+    initialSettings.current = userLocale;
 
     return {
       [fieldNames.LOCALE]: userLocale || tenantLocale,
     };
   };
+
+  const handleResetToDefault = useCallback(async () => {
+    const numberingSystem = tenantSettings.numberingSystem;
+    const fullLocale = getFullLocale(tenantLocale, numberingSystem);
+
+    await updateUserSetting({
+      scope: userOwnLocaleConfig.SCOPE,
+      key: userOwnLocaleConfig.KEY,
+      [fieldNames.LOCALE]: null,
+    });
+
+    stripes.setLocale(fullLocale);
+  }, [updateUserSetting, stripes, tenantSettings, tenantLocale]);
+
+  const lastMenu = useMemo(() => (
+    <PaneMenu>
+      <Button
+        onClick={handleResetToDefault}
+        buttonStyle="primary"
+        disabled={!userHasSetLocalePreferences}
+        marginBottom0
+      >
+        <FormattedMessage id="ui-myprofile.settings.languageLocalization.resetToDefault" />
+      </Button>
+    </PaneMenu>
+  ), [handleResetToDefault, userHasSetLocalePreferences]);
 
   return (
     <CommandList commands={defaultKeyboardShortcuts}>
@@ -96,6 +125,7 @@ const LanguageLocalization = () => {
           stripes={stripes}
           onBeforeSave={formatPayload}
           onAfterSave={afterSave}
+          lastMenu={lastMenu}
         >
           <Field
             id={fieldNames.LOCALE}

--- a/translations/ui-myprofile/en.json
+++ b/translations/ui-myprofile/en.json
@@ -26,6 +26,7 @@
   "settings.languageLocalization.label": "Language & localization",
   "settings.languageLocalization.fieldLocale.label": "Locale (for language display, date format etc.)",
   "settings.languageLocalization.tenantDefault": "Tenant default",
+  "settings.languageLocalization.resetToDefault": "Reset to default",
   "settings.appNavOrder.visibleInstruction": "Drag & drop to change the display order of FOLIO applications.",
   "settings.appNavOrder.saveError": "There was a problem saving app list order.",
   "settings.appNavOrder.resetError": "There was a problem resetting the app order.",


### PR DESCRIPTION
## Description
Let users reset their localization settings to match tenant preferences.

@zburke can we just import `config` from `stripes-config` like that? Should we add something like `useStripesConfig` hook to `stripes-core` for these purposes?

## Screenshots

https://github.com/user-attachments/assets/94a7ba15-9db0-4d16-9f2e-9cc1dc6df8a1

## Issues
[UIMPROF-115](https://folio-org.atlassian.net/browse/UIMPROF-115)