### PR TITLE
UIMPROF-124 My profile -> Language and localization does not follow Tenant locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Provide application icon. Refs UIMPROF-106.
 * Add `stripes-core.settings.read` permission to app and settings permissions. Refs UIMPROF-122.
 * Read config data from `stripes-core` instead of `stripes-config`. Refs UIMPROF-123.
+* Use `locale` API to fetch tenant locale settings. Fixes UIMPROF-124.
 
 ## 10.0.0 (https://github.com/folio-org/ui-myprofile/tree/v10.0.0) (2025-03-14)
 [Full Changelog](https://github.com/folio-org/ui-myprofile/compare/v9.2.0...v10.0.0)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
       }
     ],
     "okapiInterfaces": {
-      "settings": "1.0"
+      "settings": "1.0",
+      "locale": "1.0"
     },
     "displayName": "ui-myprofile.meta.title",
     "route": "/myprofile",
@@ -45,7 +46,8 @@
           "mod-settings.entries.item.put",
           "mod-settings.owner.read.stripes-core.prefs.manage",
           "mod-settings.owner.write.stripes-core.prefs.manage",
-          "mod-settings.global.read.stripes-core.prefs.manage"
+          "mod-settings.global.read.stripes-core.prefs.manage",
+          "locale.item.get"
         ]
       },
       {
@@ -96,11 +98,11 @@
   "devDependencies": {
     "@folio/eslint-config-stripes": "^8.0.0",
     "@folio/jest-config-stripes": "^3.0.0",
-    "@folio/stripes": "^10.0.0",
+    "@folio/stripes": "^10.1.0",
     "@folio/stripes-cli": "^4.0.0",
     "@folio/stripes-components": "^13.0.0",
     "@folio/stripes-connect": "^10.0.0",
-    "@folio/stripes-core": "^11.0.0",
+    "@folio/stripes-core": "^11.1.0",
     "@folio/stripes-logger": "^1.0.0",
     "@folio/stripes-smart-components": "^10.0.0",
     "core-js": "^3.6.4",
@@ -130,7 +132,7 @@
     "redux-form": "^8.3.7"
   },
   "peerDependencies": {
-    "@folio/stripes": "^10.0.0",
+    "@folio/stripes": "^10.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-intl": "^7.1.5",

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -1,0 +1,1 @@
+export * from './useTenantLocale';

--- a/src/queries/useTenantLocale/index.js
+++ b/src/queries/useTenantLocale/index.js
@@ -1,0 +1,1 @@
+export * from './useTenantLocale';

--- a/src/queries/useTenantLocale/useTenantLocale.js
+++ b/src/queries/useTenantLocale/useTenantLocale.js
@@ -1,0 +1,31 @@
+import { useQuery } from 'react-query';
+
+import {
+  useNamespace,
+  useOkapiKy,
+  useStripes,
+} from '@folio/stripes/core';
+
+const TENANT_LOCALE_KEY = 'tenantLocale';
+
+export const useTenantLocale = () => {
+  const stripes = useStripes();
+  const ky = useOkapiKy();
+  const [namespace] = useNamespace({ key: TENANT_LOCALE_KEY });
+
+  const isLocaleApiAvailable = stripes.hasInterface('locale');
+
+  const { data: tenantLocale, isLoading: isLoadingTenantLocale } = useQuery({
+    queryKey: [namespace],
+    queryFn: () => ky.get('locale').json(),
+  }, {
+    enabled: isLocaleApiAvailable,
+  });
+
+  return {
+    tenantLocale,
+    // react-query returns isLoading as true even for disabled queries...this is an expected behaviour according to react-query docs
+    // so we need to also check for a present interface to not have false positives
+    isLoadingTenantLocale: isLoadingTenantLocale && isLocaleApiAvailable,
+  };
+};

--- a/src/queries/useTenantLocale/useTenantLocale.test.js
+++ b/src/queries/useTenantLocale/useTenantLocale.test.js
@@ -1,0 +1,70 @@
+import { waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+
+import {
+  useOkapiKy,
+  useNamespace,
+  useStripes,
+} from '@folio/stripes/core';
+
+import buildStripes from '../../../test/jest/__mock__/stripesCore.mock';
+import { useTenantLocale } from './useTenantLocale';
+
+jest.mock('@folio/stripes/core', () => ({
+  useOkapiKy: jest.fn(),
+  useNamespace: jest.fn(),
+  useStripes: jest.fn(),
+}));
+
+const queryClient = new QueryClient();
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+useStripes.mockReturnValue(buildStripes({
+  hasInterface: () => true,
+}));
+
+describe('useTenantLocale', () => {
+  const mockLocaleData = {
+    locale: 'en-US',
+    numberingSystem: 'latn',
+    timezone: 'America/New_York',
+    currency: 'USD',
+  };
+
+  const kyMock = {
+    get: jest.fn(),
+    put: jest.fn(),
+  };
+
+  beforeEach(() => {
+    useOkapiKy.mockReturnValue(kyMock);
+    useNamespace.mockReturnValue(['tenantLocale']);
+
+    kyMock.get.mockReturnValue({
+      json: () => Promise.resolve(mockLocaleData),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when fetching tenant locale data', () => {
+    it('should fetch data on mount', async () => {
+      const { result } = renderHook(() => useTenantLocale(), { wrapper });
+
+      await waitFor(() => expect(result.current.isLoadingTenantLocale).toBeFalsy());
+
+      expect(kyMock.get).toHaveBeenCalledWith('locale');
+      expect(result.current.tenantLocale).toEqual(mockLocaleData);
+    });
+  });
+});

--- a/src/queries/useTenantLocale/useTenantLocale.test.js
+++ b/src/queries/useTenantLocale/useTenantLocale.test.js
@@ -1,5 +1,3 @@
-import { waitFor } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
 import {
   QueryClient,
   QueryClientProvider,
@@ -10,6 +8,10 @@ import {
   useNamespace,
   useStripes,
 } from '@folio/stripes/core';
+import {
+  waitFor,
+  renderHook,
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import buildStripes from '../../../test/jest/__mock__/stripesCore.mock';
 import { useTenantLocale } from './useTenantLocale';

--- a/src/settings/LanguageLocalization/LanguageLocalization.js
+++ b/src/settings/LanguageLocalization/LanguageLocalization.js
@@ -15,15 +15,16 @@ import {
 } from '@folio/stripes/components';
 import {
   TitleManager,
-  tenantLocaleConfig,
   useStripes,
   userOwnLocaleConfig,
   getFullLocale,
   useSettings,
+  useConfigurations,
 } from '@folio/stripes/core';
 import { ConfigManager } from '@folio/stripes/smart-components';
 
 import { localesList } from './utils';
+import { useTenantLocale } from '../../queries';
 
 const fieldNames = {
   LOCALE: 'locale',
@@ -35,12 +36,21 @@ const LanguageLocalization = () => {
 
   const initialSettings = useRef();
 
-  const {
-    settings: tenantSettings,
-  } = useSettings({
-    scope: tenantLocaleConfig.SCOPE,
-    key: tenantLocaleConfig.KEY,
+  const { tenantLocale: tenantLocaleModLocale } = useTenantLocale();
+
+  const { data: tenantLocaleConfigurations = {} } = useConfigurations({
+    module: 'ORG',
+    configName: 'localeSettings',
   });
+
+  const tenantLocaleConfigurationsJsonString = tenantLocaleConfigurations?.configs?.[0]?.value;
+  const tenantLocaleConfigurationsParsed = tenantLocaleConfigurationsJsonString
+    ? JSON.parse(tenantLocaleConfigurationsJsonString)
+    : {};
+
+  const tenantLocaleSetting = stripes.hasInterface('locale')
+    ? tenantLocaleModLocale
+    : tenantLocaleConfigurationsParsed;
 
   const {
     settings: userSettings,
@@ -56,8 +66,8 @@ const LanguageLocalization = () => {
   const userHasSetLocalePreferences = !!userSettings[fieldNames.LOCALE];
 
   // tenant configuration might not have a set locale - try stripes-config locale and default to en-US
-  const tenantLocale = tenantSettings[fieldNames.LOCALE] || stripes.locale || 'en-US';
-  const localesOptions = useMemo(() => localesList(intl, tenantSettings[fieldNames.LOCALE]), [intl, tenantSettings]);
+  const tenantLocale = tenantLocaleSetting?.[fieldNames.LOCALE] || stripes.locale || 'en-US';
+  const localesOptions = useMemo(() => localesList(intl, tenantLocaleSetting?.[fieldNames.LOCALE]), [intl, tenantLocaleSetting]);
 
   const formatPayload = (newSettings) => {
     return {
@@ -85,7 +95,7 @@ const LanguageLocalization = () => {
   };
 
   const handleResetToDefault = useCallback(async () => {
-    const numberingSystem = tenantSettings.numberingSystem;
+    const numberingSystem = tenantLocaleSetting?.numberingSystem;
     const fullLocale = getFullLocale(tenantLocale, numberingSystem);
 
     await updateUserSetting({
@@ -94,7 +104,7 @@ const LanguageLocalization = () => {
     });
 
     stripes.setLocale(fullLocale);
-  }, [updateUserSetting, stripes, tenantSettings, tenantLocale]);
+  }, [updateUserSetting, stripes, tenantLocaleSetting, tenantLocale]);
 
   const lastMenu = useMemo(() => (
     <PaneMenu>

--- a/src/settings/LanguageLocalization/LanguageLocalization.js
+++ b/src/settings/LanguageLocalization/LanguageLocalization.js
@@ -19,7 +19,6 @@ import {
   userOwnLocaleConfig,
   getFullLocale,
   useSettings,
-  useConfigurations,
 } from '@folio/stripes/core';
 import { ConfigManager } from '@folio/stripes/smart-components';
 
@@ -36,21 +35,7 @@ const LanguageLocalization = () => {
 
   const initialSettings = useRef();
 
-  const { tenantLocale: tenantLocaleModLocale } = useTenantLocale();
-
-  const { data: tenantLocaleConfigurations = {} } = useConfigurations({
-    module: 'ORG',
-    configName: 'localeSettings',
-  });
-
-  const tenantLocaleConfigurationsJsonString = tenantLocaleConfigurations?.configs?.[0]?.value;
-  const tenantLocaleConfigurationsParsed = tenantLocaleConfigurationsJsonString
-    ? JSON.parse(tenantLocaleConfigurationsJsonString)
-    : {};
-
-  const tenantLocaleSetting = stripes.hasInterface('locale')
-    ? tenantLocaleModLocale
-    : tenantLocaleConfigurationsParsed;
+  const { tenantLocale: tenantLocaleConfig } = useTenantLocale();
 
   const {
     settings: userSettings,
@@ -66,8 +51,8 @@ const LanguageLocalization = () => {
   const userHasSetLocalePreferences = !!userSettings[fieldNames.LOCALE];
 
   // tenant configuration might not have a set locale - try stripes-config locale and default to en-US
-  const tenantLocale = tenantLocaleSetting?.[fieldNames.LOCALE] || stripes.locale || 'en-US';
-  const localesOptions = useMemo(() => localesList(intl, tenantLocaleSetting?.[fieldNames.LOCALE]), [intl, tenantLocaleSetting]);
+  const tenantLocale = tenantLocaleConfig?.[fieldNames.LOCALE] || stripes.locale || 'en-US';
+  const localesOptions = useMemo(() => localesList(intl, tenantLocaleConfig?.[fieldNames.LOCALE]), [intl, tenantLocaleConfig]);
 
   const formatPayload = (newSettings) => {
     return {
@@ -95,7 +80,7 @@ const LanguageLocalization = () => {
   };
 
   const handleResetToDefault = useCallback(async () => {
-    const numberingSystem = tenantLocaleSetting?.numberingSystem;
+    const numberingSystem = tenantLocaleConfig?.numberingSystem;
     const fullLocale = getFullLocale(tenantLocale, numberingSystem);
 
     await updateUserSetting({
@@ -104,7 +89,7 @@ const LanguageLocalization = () => {
     });
 
     stripes.setLocale(fullLocale);
-  }, [updateUserSetting, stripes, tenantLocaleSetting, tenantLocale]);
+  }, [updateUserSetting, stripes, tenantLocaleConfig, tenantLocale]);
 
   const lastMenu = useMemo(() => (
     <PaneMenu>

--- a/src/settings/LanguageLocalization/LanguageLocalization.test.js
+++ b/src/settings/LanguageLocalization/LanguageLocalization.test.js
@@ -5,6 +5,7 @@ import arrayMutators from 'final-form-arrays';
 import {
   useSettings,
   useStripes,
+  useConfigurations,
   userOwnLocaleConfig,
 } from '@folio/stripes/core';
 import { ConfigManager } from '@folio/stripes/smart-components';
@@ -16,8 +17,14 @@ import {
 } from '@folio/jest-config-stripes/testing-library/react';
 
 import LanguageLocalization from './LanguageLocalization';
+import { useTenantLocale } from '../../queries';
 import Harness from '../../../test/jest/helpers/Harness';
 import buildStripes from '../../../test/jest/__mock__/stripesCore.mock';
+
+jest.mock('../../queries', () => ({
+  ...jest.requireActual('../../queries'),
+  useTenantLocale: jest.fn().mockReturnValue({}),
+}));
 
 const tenantSettings = {
   locale: 'en-US',
@@ -60,20 +67,26 @@ describe('LanguageLocalization', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    useSettings.mockImplementation(({ key }) => {
-      if (key === userOwnLocaleConfig.KEY) {
-        return {
-          settings: userSettings,
-          isLoading: false,
-          updateSetting: mockUpdateSetting,
-        };
-      }
-
+    useSettings.mockImplementation(() => {
       return {
-        settings: tenantSettings,
+        settings: userSettings,
         isLoading: false,
         updateSetting: mockUpdateSetting,
       };
+    });
+
+    useConfigurations.mockReturnValue({
+      data: {
+        configs: [{
+          value: JSON.stringify(tenantSettings),
+        }]
+      },
+      isLoading: false,
+    });
+
+    useTenantLocale.mockReturnValue({
+      tenantLocale: tenantSettings,
+      isLoadingTenantLocale: false,
     });
 
     useStripes.mockReturnValue(stripes);
@@ -131,22 +144,25 @@ describe('LanguageLocalization', () => {
     });
   });
 
-  describe('when tenant settings do not have a locale but stripes.locale is set', () => {
+  describe('when tenant settings and user settings do not have a locale but stripes.locale is set', () => {
     it('should use stripes.locale', async () => {
-      useSettings.mockImplementation(({ key }) => {
-        if (key === userOwnLocaleConfig.KEY) {
-          return {
-            settings: {},
-            isLoading: false,
-            updateSetting: mockUpdateSetting,
-          };
-        }
-
+      useTenantLocale.mockImplementation(() => {
         return {
-          settings: {},
-          isLoading: false,
-          updateSetting: mockUpdateSetting,
+          tenantLocale: {},
+          isLoadingTenantLocale: false,
         };
+      });
+
+      useConfigurations.mockReturnValue({
+        data: {
+          configs: [],
+        },
+        isLoading: false,
+      });
+
+      useSettings.mockReturnValue({
+        settings: {},
+        isLoading: false,
       });
 
       useStripes.mockReturnValue({

--- a/src/settings/LanguageLocalization/LanguageLocalization.test.js
+++ b/src/settings/LanguageLocalization/LanguageLocalization.test.js
@@ -5,8 +5,6 @@ import arrayMutators from 'final-form-arrays';
 import {
   useSettings,
   useStripes,
-  useConfigurations,
-  userOwnLocaleConfig,
 } from '@folio/stripes/core';
 import { ConfigManager } from '@folio/stripes/smart-components';
 import {
@@ -67,22 +65,11 @@ describe('LanguageLocalization', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    useSettings.mockImplementation(() => {
-      return {
-        settings: userSettings,
-        isLoading: false,
-        updateSetting: mockUpdateSetting,
-      };
-    });
-
-    useConfigurations.mockReturnValue({
-      data: {
-        configs: [{
-          value: JSON.stringify(tenantSettings),
-        }]
-      },
+    useSettings.mockImplementation(() => ({
+      settings: userSettings,
       isLoading: false,
-    });
+      updateSetting: mockUpdateSetting,
+    }));
 
     useTenantLocale.mockReturnValue({
       tenantLocale: tenantSettings,
@@ -118,19 +105,10 @@ describe('LanguageLocalization', () => {
 
   describe('when there is no locale in user settings, but it is present in tenant settings', () => {
     beforeEach(() => {
-      useSettings.mockImplementation(({ scope }) => {
-        if (scope === userOwnLocaleConfig) {
-          return {
-            settings: {},
-            isLoading: false,
-          };
-        }
-
-        return {
-          settings: tenantSettings,
-          isLoading: false,
-        };
-      });
+      useSettings.mockImplementation(() => ({
+        settings: {},
+        isLoading: false,
+      }));
     });
 
     it('should display the tenant locale', async () => {
@@ -151,13 +129,6 @@ describe('LanguageLocalization', () => {
           tenantLocale: {},
           isLoadingTenantLocale: false,
         };
-      });
-
-      useConfigurations.mockReturnValue({
-        data: {
-          configs: [],
-        },
-        isLoading: false,
       });
 
       useSettings.mockReturnValue({

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -101,6 +101,17 @@ jest.mock('@folio/stripes/core', () => {
     removeSetting: jest.fn(),
   }));
 
+  const useConfigurations = jest.fn(() => ({
+    data: {
+      configs: [{
+        value: null
+      }]
+    },
+    isLoading: false,
+  }));
+
+  const useNamespace = () => ['@folio/myprofile', jest.fn()];
+
   return {
     ...jest.requireActual('@folio/stripes/core'),
     stripesConnect: connect,
@@ -112,6 +123,8 @@ jest.mock('@folio/stripes/core', () => {
     useStripes: jest.fn(() => STRIPES),
     getFullLocale: jest.fn((languageRegion, numberingSystem) => [languageRegion, numberingSystem].filter(Boolean).join('-u-nu-')),
     useSettings,
+    useConfigurations,
+    useNamespace,
   };
 }, { virtual: true });
 

--- a/test/jest/helpers/Harness.js
+++ b/test/jest/helpers/Harness.js
@@ -6,17 +6,24 @@ import {
   QueryClient,
 } from 'react-query';
 
-import { CalloutContext } from '@folio/stripes/core';
+import {
+  CalloutContext,
+  StripesContext,
+} from '@folio/stripes/core';
 
 import translationsProperties from './translationsProperties';
-import translations from '../../../translations/ui-myprofile/en';
 import prefixKeys from './prefixKeys';
+import buildStripes from '../__mock__/stripesCore.mock';
+import translations from '../../../translations/ui-myprofile/en';
 
 const client = new QueryClient();
+
+const STRIPES = buildStripes();
 
 const Harness = ({
   children,
   translations: translationsConfig,
+  stripes,
 }) => {
   const allTranslations = prefixKeys(translations);
 
@@ -32,19 +39,21 @@ const Harness = ({
 
   return (
     <QueryClientProvider client={client}>
-      <CalloutContext.Provider value={{ sendCallout: () => { } }}>
-        <IntlProvider
-          locale="en"
-          key="en"
-          timeZone="UTC"
-          onWarn={() => {}}
-          onError={() => {}}
-          defaultRichTextElements={defaultRichTextElements}
-          messages={allTranslations}
-        >
-          {children}
-        </IntlProvider>
-      </CalloutContext.Provider>
+      <StripesContext.Provider value={stripes || STRIPES}>
+        <CalloutContext.Provider value={{ sendCallout: () => { } }}>
+          <IntlProvider
+            locale="en"
+            key="en"
+            timeZone="UTC"
+            onWarn={() => {}}
+            onError={() => {}}
+            defaultRichTextElements={defaultRichTextElements}
+            messages={allTranslations}
+          >
+            {children}
+          </IntlProvider>
+        </CalloutContext.Provider>
+      </StripesContext.Provider>
     </QueryClientProvider>
   );
 };


### PR DESCRIPTION
## Description
Fix issue with My Profile Languange and localization form not following tenant locale when resetting.

There were two problems:
1. Language and localization was still using `mod-settings`' `/settings/entries` API after we migrated to `locale` API.
2. There was no fallback to `mod-configurations`.

## Issues
[UIMPROF-124](https://folio-org.atlassian.net/browse/UIMPROF-124)